### PR TITLE
Add Linux compatibility for setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 -->
 
 > [!NOTE]
-> Supports: Windows 10, 11 [Other Versions untested]<br>
+> Supports: Windows 10, 11, Linux [Other Versions untested]<br>
 > Fully request based, i will not add selfbot support using discord.py-self etc<br>
 > Star the Repo for more amazing Updates in the Future.<br>
 > Make sure that you have `VirtualTerminalLevel` set to `1` for the best experience. --> [Tutorial](https://www.youtube.com/watch?v=HeJOyEw3RtM)<br>
@@ -32,7 +32,7 @@
 > 
 > 2. **For Source Code:**
 >    - Ensure [Python](https://www.python.org/downloads/) 3.10 or later is installed on your system.
->    - Run `setup.bat` to install the required libraries.
+>    - Run `setup.bat` (Windows) or `setup.sh` (Linux) to install the required libraries.
 >    - After that's done, run `schuh.py`
 > 
 > 3. **For Executable (exe):**

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+if [ ! -f requirements.txt ]; then
+    echo "requirements.txt not found."
+    exit 1
+fi
+
+while IFS= read -r module; do
+    echo "Installing $module..."
+    if ! pip install "$module"; then
+        echo "Failed to install $module."
+        exit 1
+    fi
+done < requirements.txt
+
+echo "All modules installed successfully."


### PR DESCRIPTION
Related to #8

Add Linux compatibility for setup script.

* **setup.sh**: Create a new `setup.sh` script to install required libraries on Linux. Check if `requirements.txt` exists, exit if not found. Read `requirements.txt` and install each module using `pip`. Print success message after all modules are installed.
* **README.md**: Add instructions for running `setup.sh` on Linux. Mention Linux compatibility in the supported platforms section.

